### PR TITLE
fix inconsistent documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ module.exports = {
 WEBPACK_LOADER = {
     'DEFAULT': {
         'CACHE': not DEBUG,
-        'BUNDLE_DIR_NAME': 'webpack_bundles/', # must end with slash
-        'STATS_FILE': 'webpack-stats.json',
+        'BUNDLE_DIR_NAME': 'bundles/', # must end with slash
+        'STATS_FILE': os.path.join(BASE_DIR, 'webpack-stats.json'),
         'POLL_INTERVAL': 0.1,
         'IGNORE': ['.+\.hot-update.js', '.+\.map']
     }


### PR DESCRIPTION
Make the example consistent with detailed explanation.

The example given was inconsistent with the detailed explanation below it, and this led to some very confusing errors.
